### PR TITLE
Adding all account tags as SSM parameters to the target account to avoid mgmt account permissions

### DIFF
--- a/sources/aft-lambda-layer/aft_common/constants.py
+++ b/sources/aft-lambda-layer/aft_common/constants.py
@@ -66,3 +66,5 @@ SSM_PARAM_ACCOUNT_TERRAFORM_VERSION = "/aft/config/terraform/version"
 SSM_PARAM_AFT_METRICS_REPORTING = "/aft/config/metrics-reporting"
 SSM_PARAM_AFT_METRICS_REPORTING_UUID = "/aft/config/metrics-reporting-uuid"
 SSM_PARAMETER_PATH = "/aft/account-request/custom-fields/"
+ACCOUNT_TAGS_SSM_PARAMETER_PATH = "/aft/account-request/account-tags/"
+


### PR DESCRIPTION
# Contributing to the AWS Control Tower Account Factory for Terraform

Thank you for your interest in contributing to the AWS Control Tower Account Factory for Terraform.

At this time, we are not accepting contributions. If contributions are accepted in the future, the AWS Control Tower Account Factory for Terraform is released under the [Apache license](http://aws.amazon.com/apache2.0/) and any code submitted will be released under that license.

If you have a feature request, please create an issue using the Feature Request template, thanks!
